### PR TITLE
fix: s/Github/GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A Nouns marketplace for originals and derivatives projects.
 
 # Getting started:
 
-(note: This is a github template - so all you need to do is click on the BIG GREEN "Use this template" Button to create a new repo under your GH account - we recommend using [▲ Vercel](https://vercel.com/) for deployment)
+(note: This is a GitHub template - so all you need to do is click on the BIG GREEN "Use this template" Button to create a new repo under your GH account - we recommend using [▲ Vercel](https://vercel.com/) for deployment)
 
 > Clone the repo
 

--- a/compositions/Footer/FooterComposition.tsx
+++ b/compositions/Footer/FooterComposition.tsx
@@ -26,7 +26,7 @@ export function FooterComposition() {
             target="_blank"
           >
             <Label size="lg" rel="noreferrer">
-              Github
+              GitHub
             </Label>
             <Icon id="ArrowRightAngle" size="sm" />
           </Flex>


### PR DESCRIPTION
## Summary

Closes #94 

Fixes spelling for `GitHub` in the footer and README docs, respectively! 🔬