### PR TITLE
fix: s/You're/Your

### DIFF
--- a/@noun-auction/components/AuctionUi/NounsBidForm.tsx
+++ b/@noun-auction/components/AuctionUi/NounsBidForm.tsx
@@ -159,7 +159,7 @@ export function NounsBidForm({ onConfirmation, ...props }: NounsBidFormProps) {
             variant="secondary"
             borderRadius="curved"
           >
-            You're bid has been placed!
+            Your bid has been placed!
           </Button>
         )}
       </form>


### PR DESCRIPTION
## Summary

Closes #97

This PR updates a contraction to a single word for correctness in the product copy. 🔬