### PR TITLE
fix for uncentered HorizontalMenu

### DIFF
--- a/components/HorizontalMenu/HorizontalMenu.css.ts
+++ b/components/HorizontalMenu/HorizontalMenu.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { color, space, atoms, media } from '@zoralabs/zord'
+import { color, atoms, media } from '@zoralabs/zord'
 
 export const horizontalMenuButton = style([
   {

--- a/components/HorizontalMenu/HorizontalMenu.tsx
+++ b/components/HorizontalMenu/HorizontalMenu.tsx
@@ -31,7 +31,11 @@ export function HorizontalMenu({
   )
 
   return (
-    <Flex className={horizontalMenuWrapper} {...props}>
+    <Flex
+      className={['zora-horizontalmenu', horizontalMenuWrapper]}
+      justify="center"
+      {...props}
+    >
       {items.map((item) => (
         <Button
           key={item.label}


### PR DESCRIPTION
**Before**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12784/190211342-dc2f846b-214b-4d8c-bbda-4e2fbb7b205e.png">
**After**
<img width="1440" alt="Screen Shot 2022-09-14 at 12 31 39 PM" src="https://user-images.githubusercontent.com/12784/190211372-f0d631ef-cb43-4116-8c24-1b89f79bbcf4.png">
