### PR TITLE
add useOptionalImageURIDecode hook to gracefully handle broken SVGs

### DIFF
--- a/@media/CollectionThumbnail.tsx
+++ b/@media/CollectionThumbnail.tsx
@@ -4,6 +4,7 @@ import { NFTObject, useNFT } from '@zoralabs/nft-hooks'
 import { ImageWithNounFallback } from 'components'
 import { useRawImageTransform } from './hooks/useRawImageTransform'
 import { useMemo } from 'react'
+import { useOptionalImageURIDecode } from './hooks/useImageURIDecode'
 
 export type SizeProps = '100%' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | undefined
 
@@ -47,7 +48,13 @@ export function CollectionThumbnail({
   ...props
 }: CollectionThumbnailProps) {
   const { data: nft = initialNFT } = useNFT(collectionAddress, tokenId)
-  const { image } = useRawImageTransform(nft?.media?.image?.uri)
+  const { image: rawImageFallback } = useRawImageTransform(nft?.media?.image?.uri)
+  const decodedImgSrc = useOptionalImageURIDecode(nft!) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
+  const srcImg = useMemo(
+    () => decodedImgSrc ?? rawImageFallback,
+    [decodedImgSrc, rawImageFallback]
+  )
+
   const thumbnailSize = useMemo(() => returnThumbnailSize(size), [size])
 
   if (!collectionAddress) return null
@@ -60,7 +67,7 @@ export function CollectionThumbnail({
         className={['zora-media__nft-thumbnail', nftThumbnail]}
       >
         <ImageWithNounFallback
-          srcImg={image}
+          srcImg={srcImg}
           tokenId={tokenId}
           tokenContract={collectionAddress}
         />

--- a/@media/NFTCard/NFTCard.tsx
+++ b/@media/NFTCard/NFTCard.tsx
@@ -12,23 +12,17 @@ import {
 import { CollectionThumbnail } from '@media/CollectionThumbnail'
 import { ImageWithNounFallback } from 'components'
 import { useNFTProvider, useTitleWithFallback } from '@shared'
+import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
 
 export function NFTCard() {
   const { nft, contractAddress, tokenId } = useNFTProvider()
-
   const { fallbackTitle } = useTitleWithFallback({
     contractAddress,
     tokenId,
     defaultTitle: nft?.metadata?.name,
   })
 
-  const srcImg = useMemo(
-    () =>
-      nft?.media?.mimeType === 'image/svg+xml'
-        ? nft?.media?.image?.uri
-        : nft?.media?.poster?.uri,
-    [nft?.media]
-  )
+  const srcImg = useOptionalImageURIDecode(nft!) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
 
   const useTitleScroll = useMemo(() => {
     if (nft?.metadata && nft?.metadata?.name) {

--- a/@media/hooks/useImageURIDecode.ts
+++ b/@media/hooks/useImageURIDecode.ts
@@ -1,0 +1,21 @@
+import { NFTObject } from '@zoralabs/nft-hooks'
+import { useMemo } from 'react'
+
+/**
+ * Handle non-base64 SVGs
+ * @param nft: NFTObject
+ * @returns uri as string
+ */
+
+export function useOptionalImageURIDecode(nft: NFTObject) {
+  return useMemo(() => {
+    if (nft?.media?.mimeType === 'image/svg+xml') {
+      const uri = nft?.media?.image?.uri
+      return uri?.includes('data:image/svg+xml')
+        ? uri
+        : 'data:image/svg+xml;base64,' + window.btoa(decodeURIComponent(uri!)) // If SVG is encoded as URI and not base64, decode it and convert to base64
+    } else {
+      return nft?.media?.poster?.uri
+    }
+  }, [nft?.media])
+}

--- a/@media/hooks/useImageURIDecode.ts
+++ b/@media/hooks/useImageURIDecode.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 
 /**
  * Handle non-base64 SVGs
+ * ** this hook temporarily works around normal usage of useSourceImage in Zora's nft-hooks package
  * @param nft: NFTObject
  * @returns uri as string
  */

--- a/@media/hooks/useImageURIDecode.ts
+++ b/@media/hooks/useImageURIDecode.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 /**
  * Handle non-base64 SVGs
- * ** this hook temporarily works around normal usage of useSourceImage in Zora's nft-hooks package
+ * ** this hook temporarily works around normal usage of useSourceImage in Zora's nft-hooks package by handling URI-encoded images
  * @param nft: NFTObject
  * @returns uri as string
  */
@@ -12,9 +12,7 @@ export function useOptionalImageURIDecode(nft: NFTObject) {
   return useMemo(() => {
     if (nft?.media?.mimeType === 'image/svg+xml') {
       const uri = nft?.media?.image?.uri
-      return uri?.includes('data:image/svg+xml')
-        ? uri
-        : 'data:image/svg+xml;base64,' + window.btoa(decodeURIComponent(uri!)) // If SVG is encoded as URI and not base64, decode it and convert to base64
+      return uri?.includes('data:image/svg+xml') ? uri : `data:image/svg+xml,${uri}` // proper handling of URI-encoded SVG
     } else {
       return nft?.media?.poster?.uri
     }

--- a/@noun-auction/components/DataRenderers/AuctionBidder.tsx
+++ b/@noun-auction/components/DataRenderers/AuctionBidder.tsx
@@ -63,7 +63,7 @@ export function AuctionBidder({
           {hasNonZeroHighestBidder ? (
             <Flex gap="x2" align="center">
               <Label size="md" gap="x1" align={'center'} style={{ lineHeight: '1.15' }}>
-                {ensName ? ensName : shortAddress}
+                {ensName ?? shortAddress}
               </Label>
               {useAvatar && (
                 <>

--- a/compositions/NFTPage/NFTPageHero.tsx
+++ b/compositions/NFTPage/NFTPageHero.tsx
@@ -1,15 +1,15 @@
 import { Box, BoxProps } from '@zoralabs/zord'
 import { cardImageWrapper } from '@media/NftMedia.css'
 import { nftPageHero } from './NFTPage.css'
-import { useSourceImage } from '@media/hooks/useSrcImage'
 import { useNFTProvider } from '@shared/providers/NFTProvider'
 import { ImageWithNounFallback } from 'components'
+import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
 
 export interface NFTPageHeroProps extends BoxProps {}
 
 export function NFTPageHero({ className, ...props }: NFTPageHeroProps) {
   const { nft, tokenId, contractAddress } = useNFTProvider()
-  const { srcImg } = useSourceImage(nft?.media)
+  const srcImg = useOptionalImageURIDecode(nft!) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
 
   return (
     <Box


### PR DESCRIPTION
Some Nounish NFTs have their image URI specified as encoded HTML URIs rather than base64 SVGs. This PR adds a hook that will handle these gracefully by converting them client-side.

This should ideally just be a temporary work-around and handled server-side in the API.