### PR TITLE
Fix skewed Nouns googles

### DIFF
--- a/compositions/Header/Header.css.ts
+++ b/compositions/Header/Header.css.ts
@@ -33,7 +33,6 @@ export const headerWrapper = style([
 export const nounsGlassesLink = style([
   {
     aspectRatio: '70 / 24',
-    maxHeight: '30px',
   },
   atoms({
     w: 'x25',


### PR DESCRIPTION
Recent update had the SVG flowing based on container, whereas the SVG previously had a maxHeight applied. So the maxHeight was affecting the dynamic sizing.