### PR TITLE
Hotfix DAO images

### DIFF
--- a/@media/CollectionThumbnail.tsx
+++ b/@media/CollectionThumbnail.tsx
@@ -9,8 +9,6 @@ import { useFirstTokenID } from '@shared/hooks'
 import { Box, BoxProps, Flex, Label } from '@zoralabs/zord'
 
 import { nftThumbnail } from './NftMedia.css'
-import { useOptionalImageURIDecode } from './hooks/useImageURIDecode'
-import { useRawImageTransform } from './hooks/useRawImageTransform'
 
 export type SizeProps = '100%' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | undefined
 
@@ -78,15 +76,6 @@ export function CollectionThumbnailComponent({
 }: Omit<CollectionThumbnailProps, 'tokenId' | 'collectionAddress'> & {
   token: TypeSafeToken
 }) {
-  const { image: rawImageFallback } = useRawImageTransform(token.image?.url ?? undefined)
-
-  const decodedImgSrc = useOptionalImageURIDecode(token) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
-
-  const srcImg = useMemo(
-    () => decodedImgSrc ?? rawImageFallback,
-    [decodedImgSrc, rawImageFallback]
-  )
-
   const thumbnailSize = useMemo(() => returnThumbnailSize(size), [size])
 
   return (
@@ -96,11 +85,7 @@ export function CollectionThumbnailComponent({
         borderRadius={radius}
         className={['zora-media__nft-thumbnail', nftThumbnail]}
       >
-        <ImageWithNounFallback
-          srcImg={srcImg}
-          tokenId={token.tokenId}
-          tokenContract={token.collectionAddress}
-        />
+        <ImageWithNounFallback token={token} />
       </Box>
       {showTitle && <Label size="lg">{token.collectionName}</Label>}
     </Flex>

--- a/@media/NFTCard/NFTCard.tsx
+++ b/@media/NFTCard/NFTCard.tsx
@@ -15,7 +15,6 @@ import {
   titleScroll,
   titleWrapper,
 } from '@media/NftMedia.css'
-import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
 import { useIsOwner, useNFTProvider } from '@shared'
 import { Box, Flex, Heading, Separator, Stack } from '@zoralabs/zord'
 
@@ -49,7 +48,6 @@ export function NFTCardComponent({
 }: Props & { token: TypeSafeToken }) {
   const { isOwner } = useIsOwner(token)
   const fallbackTitle = token.collectionName ?? '..'
-  const srcImg = useOptionalImageURIDecode(token) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
   const tokenId = token.tokenId
 
   const useTitleScroll = useMemo(() => {
@@ -62,13 +60,7 @@ export function NFTCardComponent({
     <Stack w="100%" position="relative" overflow="hidden" className={cardWrapper}>
       <Link href={`/collections/${collectionAddress}/${tokenId}`}>
         <Box w="100%" className={cardImageWrapper} backgroundColor="background2">
-          {collectionAddress && tokenId && (
-            <ImageWithNounFallback
-              tokenContract={collectionAddress}
-              tokenId={tokenId}
-              srcImg={srcImg}
-            />
-          )}
+          {collectionAddress && tokenId && <ImageWithNounFallback token={token} />}
         </Box>
       </Link>
       <Stack gap="x2" mt="x2" px="x4" pb="x4" flex={1}>

--- a/@media/hooks/useImageURIDecode.ts
+++ b/@media/hooks/useImageURIDecode.ts
@@ -10,13 +10,16 @@ import { TypeSafeToken } from 'validators/token'
 
 export function useOptionalImageURIDecode(token: TypeSafeToken) {
   return useMemo(() => {
+    const uri = token?.image?.url
     if (token?.image.mimeType === 'image/svg+xml') {
-      const uri = token?.image?.url
-      return uri?.includes('data:image/svg+xml') ? uri : `data:image/svg+xml,${uri}` // proper handling of URI-encoded SVG
+      return uri?.includes('data:image/svg+xml') || uri?.includes('https://api.zora.co')
+        ? uri
+        : `data:image/svg+xml,${uri}` // proper handling of URI-encoded SVG
     } else {
+      // console.log('ARWEAVE?', token?.image.mimeType)
       // FIXME: will take some data massage
       // @ts-ignore-next-line
-      return token?.image?.mediaEncoding?.poster ?? ''
+      return token?.image?.mediaEncoding?.poster ?? uri
     }
   }, [token?.image])
 }

--- a/@noun-auction/components/ActiveAuctionCard.tsx
+++ b/@noun-auction/components/ActiveAuctionCard.tsx
@@ -13,7 +13,6 @@ import {
   titleHeading,
   titleWrapper,
 } from '@media/NftMedia.css'
-import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
 import { useNounishAuctionQuery } from '@noun-auction/hooks'
 import { useIsAuctionCompleted } from '@noun-auction/hooks/useIsAuctionCompleted'
 import {
@@ -71,7 +70,6 @@ export function ActiveAuctionCardComponent({
     activeAuction,
   })
 
-  const srcImg = useOptionalImageURIDecode(token) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
   const fallbackTitle = useMemo(
     () => (token ? `${token?.collectionName} #${token?.tokenId}` : '...'),
     [token]
@@ -87,11 +85,7 @@ export function ActiveAuctionCardComponent({
     >
       <Link href={`/collections/${collectionAddress}/${tokenId}`}>
         <Box w="100%" className={cardImageWrapper} backgroundColor="tertiary">
-          <ImageWithNounFallback
-            srcImg={srcImg}
-            tokenContract={collectionAddress}
-            tokenId={tokenId}
-          />
+          <ImageWithNounFallback token={token} />
         </Box>
       </Link>
       <Stack gap="x2" mt="x4" px="x4" pb="x4">

--- a/components/ImageWithNounFallback.tsx
+++ b/components/ImageWithNounFallback.tsx
@@ -1,16 +1,22 @@
+import { useMemo } from 'react'
+import { TypeSafeToken } from 'validators/token'
+
+import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
+import { useRawImageTransform } from '@media/hooks/useRawImageTransform'
 import { FallbackThumbnail } from '@noun-auction'
 
 import { ImageElement } from './ImageElement'
 
-export function ImageWithNounFallback({
-  srcImg,
-  tokenContract,
-  tokenId,
-}: {
-  srcImg?: string
-  tokenContract: string
-  tokenId: string
-}) {
+export function ImageWithNounFallback({ token }: { token: TypeSafeToken }) {
+  const { image: rawImageFallback } = useRawImageTransform(token.image?.url ?? undefined)
+
+  const decodedImgSrc = useOptionalImageURIDecode(token) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
+
+  const srcImg = useMemo(
+    () => decodedImgSrc ?? rawImageFallback,
+    [decodedImgSrc, rawImageFallback]
+  )
+
   if (srcImg) {
     return (
       <ImageElement
@@ -24,5 +30,5 @@ export function ImageWithNounFallback({
     )
   }
 
-  return <FallbackThumbnail tokenContract={tokenContract} tokenId={tokenId} />
+  return <FallbackThumbnail tokenContract={token.tokenContract} tokenId={token.tokenId} />
 }

--- a/compositions/NFTPage/NFTPageHero.tsx
+++ b/compositions/NFTPage/NFTPageHero.tsx
@@ -2,11 +2,9 @@ import { ImageWithNounFallback } from 'components'
 
 import { useToken } from 'hooks/useToken'
 
-import { TypeSafeDao } from 'validators/dao'
 import { TypeSafeToken } from 'validators/token'
 
 import { cardImageWrapper } from '@media/NftMedia.css'
-import { useOptionalImageURIDecode } from '@media/hooks/useImageURIDecode'
 import { Box, BoxProps } from '@zoralabs/zord'
 
 import { nftPageHero } from './NFTPage.css'
@@ -33,8 +31,6 @@ export function NFTPageHeroComponent({
   token,
   ...props
 }: Omit<NFTPageHeroProps, 'collectionAddress' | 'tokenId'> & { token: TypeSafeToken }) {
-  const srcImg = useOptionalImageURIDecode(token) // Handle non-base64 SVGs by decoding URI. This should be replaced when handled properly API-side
-
   return (
     <Box
       w="100%"
@@ -43,11 +39,7 @@ export function NFTPageHeroComponent({
       overflow="hidden"
       {...props}
     >
-      <ImageWithNounFallback
-        tokenContract={token.collectionAddress}
-        tokenId={token.tokenId}
-        srcImg={srcImg}
-      />
+      <ImageWithNounFallback token={token} />
     </Box>
   )
 }


### PR DESCRIPTION
- cleanup: moves use of image decoding hook into ImageWithNounFallback
- handling for SVGs sourced from zora's renderer URLs
- handling for gifs from Arweave