### PR TITLE
Quick removal of collections from homepage

### DIFF
--- a/@noun-auction/hooks/useNounsToken.ts
+++ b/@noun-auction/hooks/useNounsToken.ts
@@ -60,7 +60,7 @@ export function useNounsToken(contractAddress: string, tokenId: string) {
 
   const isIpfs = dataURI?.startsWith('ipfs://')
   const isBase64 = dataURI?.startsWith('data:application/json;base64')
-  const isHttp = dataURI?.startsWith('https://')
+  // const isHttp = dataURI?.startsWith('https://')
 
   useIpfsFile({ isIpfs, dataURI })
 
@@ -74,7 +74,7 @@ export function useNounsToken(contractAddress: string, tokenId: string) {
     if (dataURI) {
       try {
         const json = atob(data)
-        console.log({ json })
+        // console.log({ json })
         const result = JSON.parse(json)
         return result
       } catch (err) {

--- a/hooks/useNounsDaos.ts
+++ b/hooks/useNounsDaos.ts
@@ -19,7 +19,7 @@ export type AuctionVolumeReturnType =
 export function useNounsDaos() {
   const [cached, setCache] = useState([] as TypeSafeDao[])
   const { data } = useSWR<NounsDaosQuery>(
-    [`noundsDaos`],
+    [`nounsDaos`],
     () => zoraApiFetcher(NOUNS_DAOS_QUERY),
     {
       onErrorRetry: (_, _1, _2, revalidate, { retryCount }) => {
@@ -42,5 +42,6 @@ export function useNounsDaos() {
       return cached.length > 0 ? cached : []
     }
     // no need to update when cache changed!
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.nouns?.nounsDaos?.nodes])
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,6 @@
 import { HomePageHeader, PageWrapper, Seo } from 'components'
-import { CollectionRanking, DaoTable } from 'compositions'
-import { collectionAddresses } from 'constants/collection-addresses'
+import { DaoTable } from 'compositions'
 import * as styles from 'styles/styles.css'
-import { SWRConfig } from 'swr'
 
 import { NOUNS_DAOS_QUERY } from 'data/nounsDaos'
 
@@ -12,60 +10,43 @@ import React from 'react'
 import { TypeSafeDao } from 'validators/dao'
 
 import * as Sentry from '@sentry/react'
-import { zdk, zoraApiFetcher } from '@shared'
-import { CollectionSortKey, SortDirection } from '@zoralabs/zdk/dist/queries/queries-sdk'
+import { zoraApiFetcher } from '@shared'
 import { CollectionsQuery } from '@zoralabs/zdk/dist/queries/queries-sdk'
 import { Grid } from '@zoralabs/zord'
 
 export type CollectionParsed = CollectionsQuery['collections']['nodes']
 
-function Home(props: { fallback: CollectionParsed; daos: TypeSafeDao[] }) {
-  // disable client-side refetch of collection agg stat in order to stop overloading backend
-  // const { data } = useSWR('collections', collectionsService)
+function Home(props: { daos: TypeSafeDao[] }) {
   const clientDaos = useNounsDaos()
 
   return (
-    <SWRConfig value={{ fallback: props.fallback }}>
-      <PageWrapper direction="column" gap="x6" align="center">
-        <Seo />
-        <Grid
-          px={{ '@initial': 'x4', '@1024': 'x8' }}
-          gap="x2"
-          className={styles.pageGrid}
-          justify="center"
-        >
-          <HomePageHeader
-            headline="The Nouns Marketplace"
-            mt={{ '@initial': 'x6', '@1024': 'x24' }}
-            mb={{ '@initial': 'x8', '@1024': 'x24' }}
-          />
-          {props.daos?.length > 0 ? (
-            <DaoTable daos={clientDaos || props.daos} className={styles.homepageTable} />
-          ) : null}
-          <CollectionRanking
-            collections={props.fallback}
-            className={styles.homepageTable}
-          />
-        </Grid>
-      </PageWrapper>
-    </SWRConfig>
+    <PageWrapper direction="column" gap="x6" align="center">
+      <Seo />
+      <Grid
+        px={{ '@initial': 'x4', '@1024': 'x8' }}
+        gap="x2"
+        className={styles.pageGrid}
+        justify="center"
+      >
+        <HomePageHeader
+          headline="The Nouns Marketplace"
+          mt={{ '@initial': 'x6', '@1024': 'x24' }}
+          mb={{ '@initial': 'x8', '@1024': 'x24' }}
+        />
+        {props.daos?.length > 0 && (
+          <DaoTable daos={clientDaos || props.daos} className={styles.homepageTable} />
+        )}
+      </Grid>
+    </PageWrapper>
   )
 }
 
 export async function getServerSideProps() {
   try {
-    const data = await zdk.collections({
-      where: { collectionAddresses: collectionAddresses },
-      sort: { sortDirection: SortDirection.Asc, sortKey: CollectionSortKey.None },
-    })
-
     const daos = await zoraApiFetcher(NOUNS_DAOS_QUERY)
-
-    const collections = data.collections
 
     return {
       props: {
-        fallback: collections?.nodes ?? null,
         daos: daos?.nouns?.nounsDaos?.nodes ?? null,
       },
     }


### PR DESCRIPTION
This PR remove the Collections table from the homepage, as we focus on Nouns Builder-based daos, Nouns, and Lil' Nouns.

Additional PRs will remove collections from /collections and alter the routing to /daos