### PR TITLE
extensive rework of useCountdown + implementations site-wide

### DIFF
--- a/@market/components/NFTPrimaryAuctionActive.tsx
+++ b/@market/components/NFTPrimaryAuctionActive.tsx
@@ -18,10 +18,14 @@ export function NFTPrimaryAuctionActive({
   primaryAuction,
   ...props
 }: NFTPrimaryAuctionActiveProps) {
-  const { formattedCryptoHighestBidPrice, formattedUSDHighestBidPrice } =
-    useNounishAuctionHelper({
-      auction: primaryAuction,
-    })
+  const {
+    formattedCryptoHighestBidPrice,
+    formattedUSDHighestBidPrice,
+    highestBidder,
+    hasBid,
+  } = useNounishAuctionHelper({
+    auction: primaryAuction,
+  })
 
   const { formattedAuctionDataTable } = useAuctionDataTable({
     primaryAuction,
@@ -30,13 +34,12 @@ export function NFTPrimaryAuctionActive({
   return (
     <Stack gap="x4" {...props}>
       <DataTable rowSize="lg" items={formattedAuctionDataTable} />
-
       <Stack gap="x4" backgroundColor="accent" borderRadius="phat" p="x6">
         {formattedCryptoHighestBidPrice && formattedUSDHighestBidPrice && (
           <PriceWithLabel
             symbol="ETH"
             cryptoAmount={formattedCryptoHighestBidPrice}
-            usdAmount={formattedUSDHighestBidPrice}
+            usdAmount={hasBid ? formattedUSDHighestBidPrice : '$0'}
             label="Current Bid"
             invertColor
           />

--- a/@market/hooks/useNounishAuctionHelper.ts
+++ b/@market/hooks/useNounishAuctionHelper.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import { TypeSafeNounsAuction } from 'validators/auction'
 
+import { AddressZero } from '@ethersproject/constants'
+import { useCountdown } from '@noun-auction'
 import { useIsAuctionCompleted } from '@noun-auction/hooks/useIsAuctionCompleted'
 import { formatCryptoVal, isAddressMatch, numberFormatterUSDC } from '@shared'
 import { useAuth } from '@shared/hooks'
@@ -14,12 +16,14 @@ export const useNounishAuctionHelper = ({ auction }: NounishAuctionHelperProps) 
 
   const { endTime, highestBidPrice, highestBidder, winner, startTime } = auction
 
+  const { countdownText } = useCountdown(startTime, endTime)
+
   const { isEnded } = useIsAuctionCompleted({
     activeAuction: auction,
   })
 
   const hasWinner = !!winner
-  const hasBid = !!highestBidder
+  const hasBid = !!highestBidder && !isAddressMatch(highestBidder, AddressZero)
   const auctionStatus = useMemo(
     () => (Date.now() - parseInt(endTime) * 1000 > 0 ? 'Settling' : 'Live'),
     [endTime]
@@ -57,5 +61,6 @@ export const useNounishAuctionHelper = ({ auction }: NounishAuctionHelperProps) 
     highestBidder,
     formattedCryptoHighestBidPrice,
     formattedUSDHighestBidPrice,
+    countdownText,
   }
 }

--- a/@noun-auction/components/ActiveAuction/ActiveAuctionRow.tsx
+++ b/@noun-auction/components/ActiveAuction/ActiveAuctionRow.tsx
@@ -20,6 +20,7 @@ export interface ActiveAuctionRowProps {
   tokenId: string
   collectionAddress: string
   auctionCompleted: boolean
+  auctionStartTime: string
   auctionEndTime: string
   highestBid: string
   highestBidder?: string
@@ -47,6 +48,7 @@ export function ActiveAuctionRow({
   highestBid,
   highestBidder,
   auctionContractAddress,
+  auctionStartTime,
   auctionEndTime,
   tokenImage,
   collectionName,
@@ -57,6 +59,7 @@ export function ActiveAuctionRow({
       <>
         <Link href={`collections/${collectionAddress}`} passHref>
           <AuctionCountdown
+            auctionStartTime={auctionStartTime}
             auctionEndTime={auctionEndTime}
             auctionCompleted={auctionCompleted}
             direction={'row' || 'withHistory' ? 'column' : 'row'}
@@ -107,6 +110,7 @@ export function ActiveAuctionRow({
     ),
     [
       auctionCompleted,
+      auctionStartTime,
       auctionEndTime,
       collectionAddress,
       highestBid,
@@ -129,6 +133,7 @@ export function ActiveAuctionRow({
         />
         <AuctionCountdown
           auctionCompleted={auctionCompleted}
+          auctionStartTime={auctionStartTime}
           auctionEndTime={auctionEndTime}
           direction="row"
           showLabels={showLabels}
@@ -137,7 +142,7 @@ export function ActiveAuctionRow({
         />
       </Stack>
     ),
-    [auctionCompleted, auctionEndTime, highestBidder, showLabels]
+    [auctionCompleted, auctionEndTime, auctionStartTime, highestBidder, showLabels]
   )
 
   return (

--- a/@noun-auction/components/ActiveAuction/AuctionCountdown.tsx
+++ b/@noun-auction/components/ActiveAuction/AuctionCountdown.tsx
@@ -1,8 +1,4 @@
-import { fromUnixTime, intervalToDuration } from 'date-fns'
-
-import { useMemo, useState } from 'react'
-
-import { useInterval } from '@noun-auction/hooks/useInterval'
+import { useCountdown } from '@noun-auction/hooks'
 import { sideBarUpperLabel } from '@noun-auction/styles/NounishStyles.css'
 import { lightFont } from '@shared'
 import { Flex, FlexProps, Label } from '@zoralabs/zord'
@@ -14,6 +10,7 @@ interface CountdownProps extends FlexProps {
   layout?: string
   className?: string[]
   auctionCompleted: boolean
+  auctionStartTime: string
   auctionEndTime: string
 }
 
@@ -24,22 +21,10 @@ export function AuctionCountdown({
   direction = 'row',
   layout,
   auctionCompleted,
+  auctionStartTime,
   auctionEndTime,
 }: CountdownProps) {
-  const [now, setNow] = useState(new Date())
-
-  const countdownText = useMemo(() => {
-    if (auctionCompleted || !auctionEndTime) return ''
-
-    const { hours, minutes, seconds } = intervalToDuration({
-      start: now,
-      end: fromUnixTime(parseInt(auctionEndTime)),
-    })
-
-    return [hours + 'h', minutes + 'm', seconds + 's'].join(' ')
-  }, [auctionCompleted, auctionEndTime, now])
-
-  useInterval(() => setNow(new Date()), 1000)
+  const { countdownText } = useCountdown(auctionStartTime, auctionEndTime)
 
   return (
     <Flex direction={direction} wrap="wrap" gap={direction === 'row' ? 'x2' : 'x0'}>
@@ -66,4 +51,4 @@ export function AuctionCountdown({
   )
 }
 
-AuctionCountdown.whyDidYouRender = true
+// AuctionCountdown.whyDidYouRender = true

--- a/@noun-auction/components/ActiveAuctionCard.tsx
+++ b/@noun-auction/components/ActiveAuctionCard.tsx
@@ -65,7 +65,7 @@ export function ActiveAuctionCardComponent({
   activeAuction: TypeSafeNounsAuction
   token: TypeSafeToken
 }) {
-  const { collectionAddress, endTime } = activeAuction
+  const { collectionAddress, endTime, startTime } = activeAuction
   const { isEnded: auctionCompleted } = useIsAuctionCompleted({
     activeAuction,
   })
@@ -130,6 +130,7 @@ export function ActiveAuctionCardComponent({
         <Grid className={activeAuctionCardData}>
           <AuctionCountdown
             auctionCompleted={auctionCompleted}
+            auctionStartTime={startTime}
             auctionEndTime={endTime}
             showLabels
             align="flex-start"

--- a/@noun-auction/components/AuctionUi/NounsBidFormComponent.tsx
+++ b/@noun-auction/components/AuctionUi/NounsBidFormComponent.tsx
@@ -98,6 +98,7 @@ export function NounsBidFormComponent({
         <Stack gap="x4" mb="x4">
           <AuctionCountdown
             auctionCompleted={auctionCompleted}
+            auctionStartTime={activeAuction.startTime}
             auctionEndTime={activeAuction.endTime}
             direction="row"
             layout="row"

--- a/@noun-auction/components/DataRenderers/AuctionHighBid.tsx
+++ b/@noun-auction/components/DataRenderers/AuctionHighBid.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react'
-
 import { sidebarHighBid } from '@noun-auction/styles/NounishStyles.css'
 import { lightFont } from '@shared'
 import { Flex, FlexProps, Label } from '@zoralabs/zord'

--- a/@noun-auction/components/NounishAuction.tsx
+++ b/@noun-auction/components/NounishAuction.tsx
@@ -70,6 +70,7 @@ export function NounishAuction({
       collectionAddress,
       address: auctionContractAddress,
       endTime: auctionEndTime,
+      startTime: auctionStartTime,
     } = activeAuction
 
     return (
@@ -81,6 +82,7 @@ export function NounishAuction({
         tokenId={tokenId}
         collectionAddress={collectionAddress}
         auctionContractAddress={auctionContractAddress}
+        auctionStartTime={auctionStartTime}
         auctionEndTime={auctionEndTime}
         {...props}
       />
@@ -104,6 +106,7 @@ type NounishAuctionComponentProps = {
   className?: ClassValue | null
   showLabels?: boolean
   tokenId: string
+  auctionStartTime: string
   auctionEndTime: string
   collectionAddress: string
   auctionContractAddress: string

--- a/@noun-auction/hooks/useCountdown.ts
+++ b/@noun-auction/hooks/useCountdown.ts
@@ -1,17 +1,11 @@
-import { getUnixTime } from 'date-fns'
+import { fromUnixTime, getUnixTime, intervalToDuration } from 'date-fns'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
+
+import { useInterval } from './useInterval'
 
 export const useCountdown = (start?: string, end?: string) => {
   const [now, setNow] = useState(new Date())
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNow(new Date())
-    }, 1000)
-
-    return () => clearInterval(interval)
-  })
 
   const isEnded = useMemo(() => {
     if (!end) return true
@@ -19,8 +13,22 @@ export const useCountdown = (start?: string, end?: string) => {
     return getUnixTime(now) >= parseInt(end)
   }, [end, now])
 
+  const countdownText = useMemo(() => {
+    if (isEnded || !end) return ''
+
+    const { days, hours, minutes, seconds } = intervalToDuration({
+      start: now,
+      end: fromUnixTime(parseInt(end)),
+    })
+
+    return [days + 'd', hours + 'h', minutes + 'm', seconds + 's'].join(' ')
+  }, [isEnded, end, now])
+
+  useInterval(() => setNow(new Date()), 1000)
+
   return {
     isEnded,
+    countdownText,
     now,
   }
 }

--- a/@noun-auction/hooks/useIsAuctionCompleted.tsx
+++ b/@noun-auction/hooks/useIsAuctionCompleted.tsx
@@ -1,5 +1,3 @@
-import { fromUnixTime, intervalToDuration } from 'date-fns'
-
 import { useMemo } from 'react'
 import { TypeSafeNounsAuction } from 'validators/auction'
 
@@ -11,25 +9,12 @@ export const useIsAuctionCompleted = ({
 }: {
   activeAuction: TypeSafeNounsAuction
 }) => {
-  const { isEnded, now } = useCountdown(activeAuction?.startTime, activeAuction?.endTime)
-
-  const countdownText = useMemo(() => {
-    if (isEnded || !activeAuction?.startTime || !activeAuction?.endTime) return ''
-
-    const { hours, minutes, seconds } = intervalToDuration({
-      start: now,
-      end: fromUnixTime(parseInt(activeAuction?.endTime || '0')),
-    })
-
-    return [hours + 'h', minutes + 'm', seconds + 's'].join(' ')
-  }, [isEnded, activeAuction?.startTime, now, activeAuction?.endTime])
-
+  const { isEnded } = useCountdown(activeAuction?.startTime, activeAuction?.endTime)
   const result = useMemo(() => {
     return {
       isEnded,
-      countdownText,
     }
-  }, [isEnded, countdownText])
+  }, [isEnded])
 
   return result
 }


### PR DESCRIPTION
Context: Auction countdown wasn't configured to allow output for auctions of > 24h, meaning they'd always show as less than 24h with accurate hour, minute, and seconds, but not showing days at all.

I've consolidated the implementation in useCountdown and ensure that it's working in various contexts, being called from different places.