### PR TITLE
Fix for active markets bug

### DIFF
--- a/@market/components/NFTPrimaryAuction.tsx
+++ b/@market/components/NFTPrimaryAuction.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { TypeSafeNounsAuction } from 'validators/auction'
 
 import { useNounishAuctionHelper } from '@market/hooks/useNounishAuctionHelper'
@@ -9,11 +10,13 @@ import { NFTPrimaryAuctionActive, NFTPrimaryAuctionEndedSettlement } from './'
 export interface NFTPrimaryAuctionProps extends FlexProps {
   nftObj: NFTObject
   primaryAuction: TypeSafeNounsAuction
+  isActiveAuctionToken: boolean
 }
 
 export function NFTPrimaryAuction({
   nftObj,
   primaryAuction,
+  isActiveAuctionToken,
   ...props
 }: NFTPrimaryAuctionProps) {
   const { isEnded } = useNounishAuctionHelper({
@@ -44,7 +47,15 @@ export function NFTPrimaryAuction({
   //   )
   // }
 
-  return (
-    <NFTPrimaryAuctionActive nftObj={nftObj} primaryAuction={primaryAuction} {...props} />
-  )
+  if (isActiveAuctionToken) {
+    return (
+      <NFTPrimaryAuctionActive
+        nftObj={nftObj}
+        primaryAuction={primaryAuction}
+        {...props}
+      />
+    )
+  }
+
+  return null
 }

--- a/compositions/NFTPage/NFTMarket.tsx
+++ b/compositions/NFTPage/NFTMarket.tsx
@@ -1,9 +1,14 @@
 import { OffchainOrderWithToken } from 'types/zora.api.generated'
 
+import { useMemo } from 'react'
+import { TypeSafeNounsAuction } from 'validators/auction'
+
 import { NFTPrimaryAuction } from '@market'
 import { NFTAsks } from '@market/components/NFTAsks'
+import { useNounishAuctionHelper } from '@market/hooks/useNounishAuctionHelper'
 import { useNounishAuctionQuery } from '@noun-auction'
 import { useNFTProvider } from '@shared'
+import { NFTObject } from '@zoralabs/nft-hooks'
 import { BoxProps } from '@zoralabs/zord'
 
 import { nftMarketWrapper } from './NFTPage.css'
@@ -19,12 +24,50 @@ export function NFTMarket({
   collectionAddress,
 }: NFTMarketProps) {
   const { nft: nftObj } = useNFTProvider()
-  const { activeAuction, hasActiveAuction } = useNounishAuctionQuery({
+  const { activeAuction } = useNounishAuctionQuery({
     collectionAddress,
   })
+  if (nftObj && activeAuction) {
+    return (
+      <NFTMarketComponent
+        className={className}
+        nftObj={nftObj}
+        activeAuction={activeAuction}
+        offchainOrders={offchainOrders}
+        collectionAddress={collectionAddress}
+      />
+    )
+  }
 
-  if (hasActiveAuction && nftObj) {
-    return <NFTPrimaryAuction nftObj={nftObj} primaryAuction={activeAuction!} />
+  return null
+}
+
+export function NFTMarketComponent({
+  offchainOrders,
+  className,
+  nftObj,
+  activeAuction,
+}: NFTMarketProps & {
+  nftObj: NFTObject
+  activeAuction: TypeSafeNounsAuction
+}) {
+  const isActiveAuctionToken = useMemo(
+    () => activeAuction?.tokenId === nftObj?.nft?.tokenId,
+    [nftObj?.nft?.tokenId, activeAuction?.tokenId]
+  )
+
+  const { isClaimable } = useNounishAuctionHelper({
+    auction: activeAuction,
+  })
+
+  if (isActiveAuctionToken || isClaimable) {
+    return (
+      <NFTPrimaryAuction
+        nftObj={nftObj}
+        primaryAuction={activeAuction}
+        isActiveAuctionToken={isActiveAuctionToken}
+      />
+    )
   }
 
   if (nftObj) {


### PR DESCRIPTION
Context: useNounishAuctionQuery gets the active auction for a collection. We need to verify that the active auction id matches the token id to show certain active auction states, but also allow for an item to be claimed if it's no longer the active auction.