### PR TITLE
fix for breaking API change: attribute requests require sort

### DIFF
--- a/@filter/FilterPropertySelect.tsx
+++ b/@filter/FilterPropertySelect.tsx
@@ -1,4 +1,4 @@
-import { AggregateAttribute, AggregateAttributeValue } from 'types/zora.api.generated'
+import { AggregateAttribute } from 'types/zora.api.generated'
 
 import { useMemo } from 'react'
 
@@ -8,20 +8,10 @@ import { Box, Flex, Label, Select } from '@zoralabs/zord'
 import * as styles from './CollectionsFilter.css'
 import { useCollectionFilters } from './providers/CollectionFilterProvider'
 
-function sortTraitsByName(a: AggregateAttributeValue, b: AggregateAttributeValue) {
-  return a.value < b.value ? -1 : 1
-}
-
 export function FilterPropertySelect({ traitType, valueMetrics }: AggregateAttribute) {
   const {
     filterStore: { setCollectionAttributes, filters },
   } = useCollectionFilters()
-
-  const sortedValueMetrics = useMemo(
-    // TODO: ideally this sorting functionality happens on the back-end
-    () => valueMetrics.sort(sortTraitsByName),
-    [valueMetrics]
-  )
 
   const isReset = useMemo(
     () => !filters.collectionAttributes.length,
@@ -53,7 +43,7 @@ export function FilterPropertySelect({ traitType, valueMetrics }: AggregateAttri
         }
       >
         <Box as="option" value="" key={`${traitType}-default`} w="100%" />
-        {sortedValueMetrics.map((valueMetric) => (
+        {valueMetrics.map((valueMetric) => (
           <Box as="option" value={valueMetric.value} key={valueMetric.value} w="100%">
             {valueMetric.value}
           </Box>

--- a/@filter/providers/CollectionFilterProvider.tsx
+++ b/@filter/providers/CollectionFilterProvider.tsx
@@ -52,7 +52,7 @@ export function CollectionFilterProvider({
   contractAllowList,
   children,
   filtersVisible = false,
-  enableMarketStatus = true,
+  enableMarketStatus = false,
   enableOwnerStatus = false,
   enableMediaTypes = false,
   enableSortDropdown = true,

--- a/data/aggregateAttributes.ts
+++ b/data/aggregateAttributes.ts
@@ -5,6 +5,7 @@ export const AGGREGATE_ATTRIBUTE_QUERY = gql`
     aggregateAttributes(
       where: { collectionAddresses: $addresses }
       networks: [$network]
+      sort: { sortKey: VALUE, sortDirection: ASC }
     ) {
       traitType
       valueMetrics {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -325,6 +325,78 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "AggregateAttributeSortKey",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "COUNT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NONE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VALUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AggregateAttributeSortKeySortInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "sortDirection",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SortDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortKey",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AggregateAttributeSortKey",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AggregateAttributeValue",
         "description": null,
@@ -9623,6 +9695,22 @@
                 "deprecationReason": null
               },
               {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AggregateAttributeSortKeySortInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "where",
                 "description": null,
                 "type": {
@@ -13388,6 +13476,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "PriceFilter",
+              "ofType": null
+            },
+            "defaultValue": "null",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeFilter",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimeFilter",
               "ofType": null
             },
             "defaultValue": "null",

--- a/pages/collections/[address]/index.tsx
+++ b/pages/collections/[address]/index.tsx
@@ -64,11 +64,11 @@ const Collection = ({ fallback }: { fallback: CollectionServiceProps }) => {
           header: 'Traits',
           selector: 'nouns-market-traits',
         }}
-        enablePriceRange={{
-          label: 'Price',
-          defaultState: 'open',
-          hideCurrencySelect: true,
-        }}
+        // enablePriceRange={{
+        //   label: 'Price',
+        //   defaultState: 'open',
+        //   hideCurrencySelect: true,
+        // }}
         strings={{
           NO_FILTER_RESULTS_COPY: `Sorry no ${collection?.name} NFTs are available for purchase on chain.`,
         }}

--- a/types/zora.api.generated.ts
+++ b/types/zora.api.generated.ts
@@ -58,6 +58,17 @@ export type AggregateAttribute = {
   valueMetrics: Array<AggregateAttributeValue>
 }
 
+export enum AggregateAttributeSortKey {
+  Count = 'COUNT',
+  None = 'NONE',
+  Value = 'VALUE',
+}
+
+export type AggregateAttributeSortKeySortInput = {
+  sortDirection: SortDirection
+  sortKey: AggregateAttributeSortKey
+}
+
 export type AggregateAttributeValue = {
   __typename?: 'AggregateAttributeValue'
   count: Scalars['Int']
@@ -1191,6 +1202,7 @@ export type RootQuery = {
 
 export type RootQueryAggregateAttributesArgs = {
   networks?: InputMaybe<Array<NetworkInput>>
+  sort: AggregateAttributeSortKeySortInput
   where: AggregateAttributesQueryInput
 }
 
@@ -1602,6 +1614,7 @@ export type TokensQueryFilter = {
   marketFilters?: InputMaybe<Array<MarketTypeFilter>>
   mediaType?: InputMaybe<MediaType>
   priceFilter?: InputMaybe<PriceFilter>
+  timeFilter?: InputMaybe<TimeFilter>
 }
 
 export type TokensQueryInput = {


### PR DESCRIPTION
A couple of things here:
- the SORT field that was just added to the API on the collection attributes endpoint is required, meaning breaking API changes. This fixes that on noun.market
- Disable price and market status sections of filter, since API support isn't there for nounish markets