### PR TITLE
Fix initial tab bug

### DIFF
--- a/pages/collections/[address]/index.tsx
+++ b/pages/collections/[address]/index.tsx
@@ -20,7 +20,7 @@ import { Stack } from '@zoralabs/zord'
 const Collection = ({ fallback }: { fallback: CollectionServiceProps }) => {
   const { setCurrentCollection, setCurrentCollectionCount } = useCollectionsContext()
   const { contractAddress: collectionAddress, collection, seo } = fallback
-  const [activeView, setActiveView] = useState<ActiveCollectionPageView>('about')
+  const [activeView, setActiveView] = useState<ActiveCollectionPageView>('nfts')
   const { nftCount } = useAggregate(collectionAddress)
   const { asPath } = useRouter()
   const router = useRouter()

--- a/pages/collections/[address]/index.tsx
+++ b/pages/collections/[address]/index.tsx
@@ -28,8 +28,9 @@ const Collection = ({ fallback }: { fallback: CollectionServiceProps }) => {
   useEffect(() => {
     const urlHash = asPath.split('#')[1] as ActiveCollectionPageView
     const isValidHash = ALL_COLLECTION_VIEWS && ALL_COLLECTION_VIEWS.includes(urlHash)
-    setActiveView(isValidHash ? urlHash : 'about')
-    router.push(`/collections/${collectionAddress}/#${isValidHash ? urlHash : 'nfts'}`)
+    const activeView = isValidHash ? urlHash : 'nfts'
+    setActiveView(activeView)
+    router.push(`/collections/${collectionAddress}/#${activeView}`)
     // No deps, should only run on first load:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
Logic for handling initial tab was in two places, and one of them wasn't handled when changing which would appear on initial load. This is fixed here.