### PR TITLE
Fix: missing token name in DaoRow mobile view

### DIFF
--- a/compositions/Daos/DaoRow.tsx
+++ b/compositions/Daos/DaoRow.tsx
@@ -93,6 +93,7 @@ export const DaoRowComponent = ({
           <RPCTokenInfo
             tokenImage={tokenImage}
             tokenId={tokenId}
+            tokenName={tokenName}
             collectionAddress={collectionAddress}
             collectionName={collectionName}
             cursor="pointer"


### PR DESCRIPTION
tokenName wasn't being passed as props