### PR TITLE
Adjust Nouns Center header naming

### DIFF
--- a/compositions/Header/HeaderLinks.tsx
+++ b/compositions/Header/HeaderLinks.tsx
@@ -24,7 +24,7 @@ function Links() {
           className={styles.linksMenuItem}
           size="lg"
         >
-          Noun Center
+          Nouns Center
         </Label>
       </Box>
       <Box as="li">


### PR DESCRIPTION
Should be Nouns Center, not Noun Center