### PR TITLE
Extract contracts from V3AskContractProvider into hook

### DIFF
--- a/@market/modules/V3Ask/hooks/index.ts
+++ b/@market/modules/V3Ask/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useV3AskModuleApproval'
 export * from './useV3AskTransferHelperApproval'
 export * from './useV3AskTransaction'
+export * from './useV3AskContracts'
 export * from './useFormattedV3AskInfo'
 export * from './usePrimaryAuctionDataTable'

--- a/@market/modules/V3Ask/hooks/useFormattedV3AskInfo.ts
+++ b/@market/modules/V3Ask/hooks/useFormattedV3AskInfo.ts
@@ -6,15 +6,15 @@ import { DataTableItemProps } from '@shared/components/DataTable/DataTableItem'
 import { resolvePossibleENSAddress } from '@shared/utils/resolvePossibleENSAddress'
 import { NFTObject } from '@zoralabs/nft-hooks'
 
-import { useV3AskContractContext } from '../providers/V3AskContractProvider'
 import { useV3AskStateContext } from '../providers/V3AskStateProvider'
+import { useV3AskContracts } from './useV3AskContracts'
 
 interface V3AskInfoProps {
   nft: NFTObject
 }
 
 export const useFormattedV3AskInfo = ({ nft: nftObj }: V3AskInfoProps) => {
-  const { V3Asks, PrivateAsks } = useV3AskContractContext()
+  const { V3Asks, PrivateAsks } = useV3AskContracts()
   const { finalizedV3AskDetails } = useV3AskStateContext()
   const { nft, markets } = nftObj
 

--- a/@market/modules/V3Ask/hooks/usePrivateAskModuleApproval.ts
+++ b/@market/modules/V3Ask/hooks/usePrivateAskModuleApproval.ts
@@ -3,10 +3,10 @@ import { useCallback, useMemo, useState } from 'react'
 import { useZoraV3ModuleApproval } from '@market/hooks/useZoraV3ModuleApproval'
 import { useContractTransaction } from '@shared/hooks/useContractTransaction'
 
-import { useV3AskContractContext } from '../providers/V3AskContractProvider'
+import { useV3AskContracts } from './useV3AskContracts'
 
 export function usePrivateAskModuleApproval() {
-  const { PrivateAsks } = useV3AskContractContext()
+  const { PrivateAsks } = useV3AskContracts()
   const [error, setError] = useState<string>()
 
   const { txStatus, handleTx, txInProgress } = useContractTransaction()

--- a/@market/modules/V3Ask/hooks/useV3AskContracts.tsx
+++ b/@market/modules/V3Ask/hooks/useV3AskContracts.tsx
@@ -1,6 +1,6 @@
 import { useAccount, useSigner } from 'wagmi'
 
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   ASKS_CORE_ETH_ADDRESS,
@@ -26,25 +26,7 @@ const defaultPrivateAsks = AsksPrivateEth__factory.connect(
   defaultProvider
 )
 
-export type V3AskContractContext = {
-  ModuleManager: ZoraModuleManagerInterface
-  V3Asks: AsksCoreEthInterface
-  PrivateAsks: AsksPrivateEthInterface
-  isReadOnly: boolean
-}
-
-export const V3AskContractCtx = createContext<V3AskContractContext>({
-  ModuleManager: defaultModuleManager,
-  V3Asks: defaultV3Asks,
-  PrivateAsks: defaultPrivateAsks,
-  isReadOnly: true,
-})
-
-export function useV3AskContractContext(): V3AskContractContext {
-  return useContext(V3AskContractCtx)
-}
-
-const V3AskContractProvider: React.FC = ({ children }) => {
+export function useV3AskContracts() {
   const { address } = useAccount()
   const { data: signer } = useSigner()
   const [isReadOnly, setIsReadOnly] = useState<boolean>(false)
@@ -85,18 +67,10 @@ const V3AskContractProvider: React.FC = ({ children }) => {
     }
   }, [address, isReadOnly])
 
-  return (
-    <V3AskContractCtx.Provider
-      value={{
-        ModuleManager,
-        V3Asks,
-        PrivateAsks,
-        isReadOnly,
-      }}
-    >
-      {children}
-    </V3AskContractCtx.Provider>
-  )
+  return {
+    ModuleManager,
+    V3Asks,
+    PrivateAsks,
+    isReadOnly,
+  }
 }
-
-export { V3AskContractProvider }

--- a/@market/modules/V3Ask/hooks/useV3AskModuleApproval.ts
+++ b/@market/modules/V3Ask/hooks/useV3AskModuleApproval.ts
@@ -3,10 +3,10 @@ import { useCallback, useMemo, useState } from 'react'
 import { useZoraV3ModuleApproval } from '@market/hooks/useZoraV3ModuleApproval'
 import { useContractTransaction } from '@shared/hooks/useContractTransaction'
 
-import { useV3AskContractContext } from '../providers/V3AskContractProvider'
+import { useV3AskContracts } from './useV3AskContracts'
 
 export function useV3AskModuleApproval() {
-  const { V3Asks } = useV3AskContractContext()
+  const { V3Asks } = useV3AskContracts()
   const [error, setError] = useState<string>()
 
   const { txStatus, handleTx, txInProgress } = useContractTransaction()

--- a/@market/modules/V3Ask/hooks/useV3AskTransaction.ts
+++ b/@market/modules/V3Ask/hooks/useV3AskTransaction.ts
@@ -3,17 +3,19 @@ import { BigNumber, ContractTransaction } from 'ethers'
 import { useState } from 'react'
 
 import { parseUnits } from '@ethersproject/units'
-import { useV3AskContractContext, useV3AskStateContext } from '@market/modules/V3Ask'
+import { useV3AskStateContext } from '@market/modules/V3Ask'
 import * as Sentry from '@sentry/react'
 import { useContractTransaction } from '@shared'
 import { NFTObject } from '@zoralabs/nft-hooks'
+
+import { useV3AskContracts } from './useV3AskContracts'
 
 // Define Ask Types
 export const V3_ASK: string = 'V3Ask'
 export const PRIVATE_ASK: string = 'PrivateAsk'
 export type AskType = typeof V3_ASK | typeof PRIVATE_ASK
 
-//  Define Ask Transactions
+// Define Ask Transactions
 export const CREATE_V3_ASK: string = 'createV3Ask'
 export const CANCEL_V3_ASK: string = 'cancelV3Ask'
 export const FILL_V3_ASK: string = 'fillV3Ask'
@@ -43,7 +45,7 @@ export const useV3AskTransaction = ({
   nft: nftObj,
   askType = V3_ASK,
 }: useV3AskTransactionProps) => {
-  const { V3Asks, PrivateAsks } = useV3AskContractContext()
+  const { V3Asks, PrivateAsks } = useV3AskContracts()
   const { txStatus, handleTx, txInProgress } = useContractTransaction()
   const [isSubmitting, setSubmitting] = useState<boolean>(false)
   const { setFinalizedV3AskDetails } = useV3AskStateContext()
@@ -54,7 +56,7 @@ export const useV3AskTransaction = ({
   const isPrivate: boolean = askType === PRIVATE_ASK
   const ActiveAskModule = isPrivate ? PrivateAsks : V3Asks
 
-  async function makeAskTransaction(
+  async function executeAskTransaction(
     txType: V3AskTransaction,
     price?: string, // as user-facing display value (eg. 0.0001 ETH), not raw BigNumber
     buyerAddress?: string,
@@ -141,7 +143,7 @@ export const useV3AskTransaction = ({
     buyerAddress, // for Private Asks only, unneeded for V3Asks
     rawBuyerAddress, // for Private Asks only, unneeded for V3Asks
   }: WriteAskTxValues) {
-    makeAskTransaction(CREATE_V3_ASK, price, buyerAddress, rawBuyerAddress)
+    executeAskTransaction(CREATE_V3_ASK, price, buyerAddress, rawBuyerAddress)
   }
 
   async function updateAsk({
@@ -149,13 +151,13 @@ export const useV3AskTransaction = ({
     buyerAddress, // for Private Asks only, unneeded for V3Asks
     rawBuyerAddress, // for Private Asks only, unneeded for V3Asks
   }: WriteAskTxValues) {
-    makeAskTransaction(UPDATE_V3_ASK, price, buyerAddress, rawBuyerAddress)
+    executeAskTransaction(UPDATE_V3_ASK, price, buyerAddress, rawBuyerAddress)
   }
   async function cancelAsk() {
-    makeAskTransaction(CANCEL_V3_ASK)
+    executeAskTransaction(CANCEL_V3_ASK)
   }
   async function fillAsk({ price }: AskTxValues) {
-    makeAskTransaction(FILL_V3_ASK, price)
+    executeAskTransaction(FILL_V3_ASK, price)
   }
 
   return {

--- a/@market/modules/V3Ask/providers/index.ts
+++ b/@market/modules/V3Ask/providers/index.ts
@@ -1,2 +1,1 @@
 export * from './V3AskStateProvider'
-export * from './V3AskContractProvider'

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,17 +9,22 @@ import type { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
 import NextNProgress from 'nextjs-progressbar'
 import { BlocklistGuard, CollectionsProvider } from 'providers'
+
 import 'styles/styles.css'
+
 import { SWRConfig } from 'swr'
 
 import { StrictMode, useEffect } from 'react'
 import React from 'react'
 
 import '@fontsource/inter/500.css'
-import { ContractProvider, V3AskContractProvider } from '@market'
+
+import { ContractProvider } from '@market'
 import { ModalContextProvider } from '@modal'
 import { RainbowKitProvider, getDefaultWallets, lightTheme } from '@rainbow-me/rainbowkit'
+
 import '@rainbow-me/rainbowkit/styles.css'
+
 import { ToastContextProvider } from '@toast'
 import { NFTFetchConfiguration } from '@zoralabs/nft-hooks'
 import { ZDKFetchStrategy } from '@zoralabs/nft-hooks/dist/strategies'
@@ -83,19 +88,17 @@ function MyApp({ Component, pageProps }: AppProps) {
                   <ModalContextProvider>
                     <ToastContextProvider>
                       <ContractProvider>
-                        <V3AskContractProvider>
-                          <Header />
-                          <NextNProgress
-                            color="rgba(0,0,0,.5)"
-                            startPosition={0.125}
-                            stopDelayMs={200}
-                            height={2}
-                            showOnShallow={true}
-                            options={{ showSpinner: false }}
-                          />
-                          <Component {...pageProps} />
-                          <Footer />
-                        </V3AskContractProvider>
+                        <Header />
+                        <NextNProgress
+                          color="rgba(0,0,0,.5)"
+                          startPosition={0.125}
+                          stopDelayMs={200}
+                          height={2}
+                          showOnShallow={true}
+                          options={{ showSpinner: false }}
+                        />
+                        <Component {...pageProps} />
+                        <Footer />
                       </ContractProvider>
                     </ToastContextProvider>
                   </ModalContextProvider>


### PR DESCRIPTION
Context: Because all of the V3Ask + PrivateAsk transactions are happening inside of the useV3AskTransaction hook, there's no need for a provider to surface the contracts elsewhere using the provider model. Here we simplify the code surface area by serving the contracts via a hook.

Key side benefit here is that potential use of a module would not require end users to add a provider to their _app.tsx